### PR TITLE
fix(routing): include locale in blog and product details page URLs

### DIFF
--- a/src/app/[locale]/(authUserView)/blog/PostCard.jsx
+++ b/src/app/[locale]/(authUserView)/blog/PostCard.jsx
@@ -1,14 +1,13 @@
-import "./PostCard.css"
-import Link from "next/link"
-
+import "./PostCard.css";
+import Link from "next/link";
 
 export const PostCard = (props) => {
   return (
     <div key={props.post.id} className="postItem">
-          <h3 >{props.post.title}</h3>
-        <div>
-          <Link  href={`/blog/${props.post.id}`}>read more</Link>
-        </div>
+      <h3>{props.post.title}</h3>
+      <div>
+        <Link href={`/${props.locale}/blog/${props.post.id}`}>read more</Link>
+      </div>
     </div>
-  )
-}
+  );
+};

--- a/src/app/[locale]/(authUserView)/blog/PostList.jsx
+++ b/src/app/[locale]/(authUserView)/blog/PostList.jsx
@@ -1,16 +1,15 @@
-import { PostCard } from "./PostCard"
-import "./PostCard.css"
+import { PostCard } from "./PostCard";
+import "./PostCard.css";
 
-export const PostList = (props)=> {
+export const PostList = (props) => {
   return (
     <div className="container margin-top-20px margin-bottom-20px">
-      <h2 style={{textAlign: "center"}}>B L O G</h2>
+      <h2 style={{ textAlign: "center" }}>B L O G</h2>
       <div className="postItems margin-top-20px">
-        {props.postList.map((post)=>(
-          <PostCard key={post.id} post={post} />
+        {props.postList.map((post) => (
+          <PostCard key={post.id} post={post} locale={props.locale} />
         ))}
       </div>
     </div>
-  )
-}
-
+  );
+};

--- a/src/app/[locale]/(authUserView)/blog/page.jsx
+++ b/src/app/[locale]/(authUserView)/blog/page.jsx
@@ -1,7 +1,9 @@
 import { PostList } from "./PostList";
-import {fetchPosts} from "./fetchPosts";
+import { fetchPosts } from "./fetchPosts";
 
-export default async function Blog() {
+export default async function Blog({ params }) {
   const postList = await fetchPosts();
-  return <PostList postList={postList} />
+  const locale = params?.locale || "en";
+
+  return <PostList postList={postList} locale={locale} />;
 }

--- a/src/app/[locale]/(authUserView)/products/ProductCard.jsx
+++ b/src/app/[locale]/(authUserView)/products/ProductCard.jsx
@@ -1,17 +1,26 @@
-import "./ProductCard.css"
-import Link from "next/link"
+import "./ProductCard.css";
+import Link from "next/link";
 
 export const ProductCard = (props) => {
   return (
     <div key={props.product.id} className="item">
-        <img src={props.product.thumbnail} alt={props.product.title}className="item-img"/>
-        <h4 className="item-name">{props.product.title}</h4>
-        <div>${props.product.price}</div>
-        <p className="item-desc">{props.product.description}</p>
-        <div>
-          <button className="button">Add to Cart</button>
-          <Link href={`/products/${props.product.id}`} className="moreCardBtn">more details</Link>
-        </div>
+      <img
+        src={props.product.thumbnail}
+        alt={props.product.title}
+        className="item-img"
+      />
+      <h4 className="item-name">{props.product.title}</h4>
+      <div>${props.product.price}</div>
+      <p className="item-desc">{props.product.description}</p>
+      <div>
+        <button className="button">Add to Cart</button>
+        <Link
+          href={`/${props.locale}/products/${props.product.id}`}
+          className="moreCardBtn"
+        >
+          more details
+        </Link>
+      </div>
     </div>
-  )
-}
+  );
+};

--- a/src/app/[locale]/(authUserView)/products/ProductList.jsx
+++ b/src/app/[locale]/(authUserView)/products/ProductList.jsx
@@ -1,15 +1,18 @@
-import { ProductCard } from "./ProductCard"
-import "./ProductCard.css"
+import { ProductCard } from "./ProductCard";
+import "./ProductCard.css";
 
-export const ProductList = (props)=> {
+export const ProductList = (props) => {
   return (
     <div className="container margin-bottom-20px">
       <div className="items margin-top-20px">
-        {props.productList.map((product)=>(
-          <ProductCard key={product.id} product={product} />
+        {props.productList.map((product) => (
+          <ProductCard
+            key={product.id}
+            product={product}
+            locale={props.locale}
+          />
         ))}
       </div>
     </div>
-  )
-}
-
+  );
+};

--- a/src/app/[locale]/(authUserView)/products/[id]/page.jsx
+++ b/src/app/[locale]/(authUserView)/products/[id]/page.jsx
@@ -1,8 +1,8 @@
-import { fetchProduct } from './fetchProduct'
-import Product from './product'
+import { fetchProduct } from "./fetchProduct";
+import Product from "./product";
 
-export default async function ProductPage({params}) {
-  const {id} = params;
+export default async function ProductPage({ params }) {
+  const { id, locale } = params;
   const product = await fetchProduct(id);
-  return <Product key={product.id} product={product} />
+  return <Product key={product.id} product={product} locale={locale} />;
 }

--- a/src/app/[locale]/(authUserView)/products/page.jsx
+++ b/src/app/[locale]/(authUserView)/products/page.jsx
@@ -3,28 +3,29 @@ import { ProductList } from "./ProductList.jsx";
 import { SortingButtons } from "../../../components/small/SortingButtons.jsx";
 import { Search } from "./search.jsx";
 
-export default async function Products({searchParams}) {
+export default async function Products({ params, searchParams }) {
   const { query, sortBy, order } = searchParams || "";
   const productList = await fetchProducts(query, sortBy, order);
+  const { locale } = params;
 
   const header = (
-    <h2 style={{textAlign: "center"}} className="margin-top-20px">
+    <h2 style={{ textAlign: "center" }} className="margin-top-20px">
       Item Shop
     </h2>
   );
 
   const searchAndSorting = (
-    <div style={{display: "flex", justifyContent: "space-between"}}>
+    <div style={{ display: "flex", justifyContent: "space-between" }}>
       <Search />
       <SortingButtons />
     </div>
-  ); 
+  );
 
   return (
     <div className="container">
       {header}
       {searchAndSorting}
-      <ProductList productList={productList} />
+      <ProductList productList={productList} locale={locale} />
     </div>
   );
 }


### PR DESCRIPTION
This pull request fixes the issue where the locale (en or ka) was missing from the URLs of both blog detail and product detail pages when navigating from their respective listing pages. The following changes were made:
- Modified blog/page.jsx to pass the locale from params to PostList and PostCard.
- Modified products/page.jsx to pass the locale from params to ProductList and ProductCard.
- Updated PostCard to dynamically include the locale in the href for blog detail links.
- Updated ProductCard to dynamically include the locale in the href for product detail links.